### PR TITLE
Handle null values

### DIFF
--- a/int32.js
+++ b/int32.js
@@ -18,6 +18,8 @@ class Int32 extends mongoose.SchemaType {
    */
 
   cast(val) {
+    if(null === val){ return val }
+
     var _val = Number(val);
     if (isNaN(_val)) {
       throw new mongoose.SchemaType.CastError('Int32',


### PR DESCRIPTION
Handle null values. Currently, it turns null into 0. This isn't consistent with the other types(Boolean, Date, Decimal128, Long, Number, String, etc]. This can only be noticed if you have an array of Int32 that isn't required. Mongoose doesn't put non-array null values through the parser; only arrays of values.

E.g. mongoose-long ln:54:
https://github.com/mongoosejs/mongoose-long/blob/master/lib/index.js

Thanks