### PR TITLE
chore: support mongoose 6.x.x

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -39,7 +39,7 @@ doc.test = 0x7FFFFFFF + 1;
 assert.ok(doc.validateSync() instanceof mongoose.Error);
 assert.equal(doc.validateSync().errors['test'].name, 'CastError');
 assert.equal(doc.validateSync().errors['test'].message,
-  'Cast to Int32 failed for value "2147483648" at path "test"');
+  'Cast to Int32 failed for value "2147483648" (type number) at path "test"');
 ```
 
 ## It throws a CastError if not a number
@@ -57,7 +57,7 @@ doc.test = 'NaN';
 assert.ok(doc.validateSync() instanceof mongoose.Error);
 assert.equal(doc.validateSync().errors['test'].name, 'CastError');
 assert.equal(doc.validateSync().errors['test'].message,
-  'Cast to Int32 failed for value "NaN" at path "test"');
+  'Cast to Int32 failed for value "NaN" (type string) at path "test"');
 ```
 
 ## It works with required validators

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "acquit-ignore": "0.1.0",
     "acquit-markdown": "0.1.0",
     "mocha": "5.x",
-    "mongodb": "3.x",
-    "mongoose": "5.x"
+    "mongodb": "4.x",
+    "mongoose": "6.x"
   },
   "engines": {
     "node": ">= 4.0.0"
@@ -18,7 +18,7 @@
   "license": "Apache 2.0",
   "main": "int32.js",
   "peerDependencies": {
-    "mongoose": ">= 4.4.0 || 5.x"
+    "mongoose": ">= 4.4.0 || 5.x || 6.x"
   },
   "repository": {
     "type": "git",

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -66,7 +66,7 @@ describe('API', function() {
     assert.ok(doc.validateSync() instanceof mongoose.Error);
     assert.equal(doc.validateSync().errors['test'].name, 'CastError');
     assert.equal(doc.validateSync().errors['test'].message,
-      'Cast to Int32 failed for value "2147483648" at path "test"');
+      'Cast to Int32 failed for value "2147483648" (type number) at path "test"');
     // acquit:ignore:start
     done();
     // acquit:ignore:end
@@ -85,7 +85,7 @@ describe('API', function() {
     assert.ok(doc.validateSync() instanceof mongoose.Error);
     assert.equal(doc.validateSync().errors['test'].name, 'CastError');
     assert.equal(doc.validateSync().errors['test'].message,
-      'Cast to Int32 failed for value "NaN" at path "test"');
+      'Cast to Int32 failed for value "NaN" (type string) at path "test"');
     // acquit:ignore:start
     done();
     // acquit:ignore:end


### PR DESCRIPTION
## Summary
Add `mongoose: 6.x.x` as a peer dependency.

## Details
Included `mongoose: 6.x.x` in peer dependencies list. Also fixed tests since cast error message was changed in https://github.com/Automattic/mongoose/issues/10207. 