### PR TITLE
Update package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ node_modules
 .node_repl_history
 
 package-lock.json
+yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+# dont include things like the travis config
+*.yml
+# dont include the tests
+test/
+docs.js

--- a/docs.js
+++ b/docs.js
@@ -6,10 +6,6 @@ const fs = require('fs');
 require('acquit-ignore')();
 require('acquit-markdown')();
 
-acquit.output(function(str) {
-  return str.replace(/acquit:ignore:end\s+/g, '');
-});
-
 const markdown =
   acquit.parse(fs.readFileSync('./test/examples.test.js', 'utf8'));
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "http://plugins.mongoosejs.io/plugins/int32",
   "devDependencies": {
     "acquit": "1.x",
-    "acquit-ignore": "0.1.0",
+    "acquit-ignore": "0.2.1",
     "acquit-markdown": "0.1.0",
     "mocha": "5.x",
     "mongodb": "4.x",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "engines": {
     "node": ">= 4.0.0"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "main": "int32.js",
   "peerDependencies": {
     "mongoose": ">= 4.4.0 || 5.x || 6.x"


### PR DESCRIPTION
This PR does some maintenance things:
- ignore `yarn.lock`
- update the `license` field to be SPDX compliant
- update `acquit-ignore` to 0.2.1, which should fix https://github.com/vkarpov15/acquit-ignore/issues/1
- add a npmignore to not ship files that are not necessary, see https://unpkg.com/browse/mongoose-int32@0.6.0/